### PR TITLE
usage: fix broken link in examples.mdx

### DIFF
--- a/usage/examples.mdx
+++ b/usage/examples.mdx
@@ -45,4 +45,4 @@ view(data, limit=rows)
 
 ## Learn More
 
-To explore these examples in depth and discover additional use cases, check out the [Preswald Examples](https://github.com/StructuredLabs/preswald-tutorial). You'll find comprehensive guides and example projects to help you make the most of Preswald.
+To explore these examples in depth and discover additional use cases, check out the [Preswald Examples](https://github.com/StructuredLabs/preswald/tree/main/examples). You'll find comprehensive guides and example projects to help you make the most of Preswald.


### PR DESCRIPTION
This PR fixes a broken link in examples.mdx that was returning a 404 error.  
- Updated the incorrect link to the correct URL.  
- Ensured the link works properly.  

No issue was raised since this is a minor documentation fix.  
